### PR TITLE
Не генерировать data.js каждый раз

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,7 +8,7 @@ ifneq (,$(findstring B,$(MAKEFLAGS)))
 	ENB_FLAGS := --no-cache
 endif
 
-all:: $(ENB) server
+all:: $(ENB) data.js server
 
 %:: $(ENB)
 	$(if $(findstring GNUmakefile,$@),,$(ENB) make $@ $(ENB_FLAGS))
@@ -23,6 +23,8 @@ $(ENB):: install
 .PHONY: install
 install:
 	@$(NPM) install
+
+data.js: example_data.js
 	@cp example_data.js data.js
 
 .PHONY: production development


### PR DESCRIPTION
Сейчас data.js генерируется при любом вызове `make`.
Сделал так, чтобы data.js генерировалась лишь при первом запуске и смене шаблона example_data.js
